### PR TITLE
feat: Add Super-Linter to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,18 @@ on:
   pull_request:
 
 jobs:
-
+  super-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Super-Linter
+        uses: super-linter/super-linter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_PYTHON_RUFF: true
+          VALIDATE_RUST_CLIPPY: true
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Adds Super-Linter to the GitHub Actions workflow to lint Rust and Python code.

- A new `super-lint` job is added to the CI workflow.
- The `super-lint` job uses `super-linter/super-linter@v6`.
- It is configured to only run `clippy` for Rust and `ruff` for Python.
- The existing `lint` job is preserved.