### PR TITLE
Implement ProtoArrayBuilder for message types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ env:
 
 
 .PHONY: develop
-develop: env
+develop: env protoc
 	. .venv/bin/activate && \
 		maturin develop
 

--- a/protos/ptars_protos/simple.proto
+++ b/protos/ptars_protos/simple.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
+import "google/type/date.proto";
 
 package messages;
 
@@ -142,4 +143,9 @@ message WithOptionalMessage {
 message WithTimestamp {
     google.protobuf.Timestamp timestamp = 1;
     repeated google.protobuf.Timestamp timestamps = 2;
+}
+
+message WithDate {
+    google.type.Date date = 1;
+    repeated google.type.Date dates = 2;
 }

--- a/python/test/unit/test_imported.py
+++ b/python/test/unit/test_imported.py
@@ -40,6 +40,7 @@ def test_get_dependencies():
 
     assert [d.name for d in _get_dependencies(simple_pb2.DESCRIPTOR)] == [
         "google/protobuf/timestamp.proto",
+        "google/type/date.proto",
         "ptars_protos/simple.proto",
     ]
 

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -1,15 +1,12 @@
 #[cfg(test)]
 mod tests {
-    use crate::proto_to_arrow::convert_timestamps;
     use crate::proto_to_arrow::messages_to_record_batch;
-    use arrow::array::{Array, BooleanArray, TimestampNanosecondArray};
-    use arrow_schema::{DataType, Field};
+    use arrow::array::Array;
     use prost_reflect::prost_types::{
         field_descriptor_proto::{Label, Type},
         DescriptorProto, FieldDescriptorProto, FileDescriptorProto,
     };
     use prost_reflect::{DescriptorPool, DynamicMessage, MessageDescriptor};
-    use std::sync::Arc;
 
     fn file_descriptor_proto_fixture() -> FileDescriptorProto {
         FileDescriptorProto {
@@ -118,61 +115,5 @@ mod tests {
             name_array,
             &arrow::array::StringArray::from(vec!["test", "test2"])
         );
-    }
-
-    #[test]
-    fn test_convert_timestamps() {
-        let seconds_field = Arc::new(Field::new("seconds", DataType::Int64, true));
-        let nanos_field = Arc::new(Field::new("nanos", DataType::Int32, true));
-
-        //let seconds = vec![1710330693i64, 1710330702i64];
-        let seconds_array: Arc<dyn Array> = Arc::new(arrow::array::Int64Array::from(vec![
-            1710330693i64,
-            1710330702i64,
-            0i64,
-        ]));
-        let nanos_array: Arc<dyn Array> =
-            Arc::new(arrow::array::Int32Array::from(vec![1_000, 123_456_789, 0]));
-
-        let arrays = vec![(seconds_field, seconds_array), (nanos_field, nanos_array)];
-
-        let valid = vec![true, true, false];
-        let results = convert_timestamps(&arrays, &valid);
-        assert_eq!(results.len(), 3);
-
-        let expected: TimestampNanosecondArray = arrow::array::Int64Array::from(vec![
-            1710330693i64 * 1_000_000_000i64 + 1_000i64,
-            1710330702i64 * 1_000_000_000i64 + 123_456_789i64,
-            0,
-        ])
-        .reinterpret_cast();
-
-        let mask = BooleanArray::from(vec![false, false, true]);
-        let expected_with_null = arrow::compute::nullif(&expected, &mask).unwrap();
-
-        assert_eq!(
-            results.as_ref().to_data(),
-            expected_with_null.as_ref().to_data()
-        )
-    }
-
-    #[test]
-    fn test_convert_timestamps_empty() {
-        let seconds_field = Arc::new(Field::new("seconds", DataType::Int64, true));
-        let nanos_field = Arc::new(Field::new("nanos", DataType::Int32, true));
-
-        let seconds_array: Arc<dyn Array> =
-            Arc::new(arrow::array::Int64Array::from(Vec::<i64>::new()));
-        let nanos_array: Arc<dyn Array> =
-            Arc::new(arrow::array::Int32Array::from(Vec::<i32>::new()));
-
-        let arrays = vec![(seconds_field, seconds_array), (nanos_field, nanos_array)];
-        let valid: Vec<bool> = vec![];
-        let results = convert_timestamps(&arrays, &valid);
-        assert_eq!(results.len(), 0);
-
-        let expected: TimestampNanosecondArray =
-            arrow::array::Int64Array::from(Vec::<i64>::new()).reinterpret_cast();
-        assert_eq!(results.as_ref(), &expected)
     }
 }


### PR DESCRIPTION
This change introduces a generic `ProtoArrayBuilder` for protobuf message types, which allows for a more modular and extensible way to convert protobuf messages to Arrow arrays.

Key changes:
- A new `MessageArrayBuilder` that can handle any protobuf message by recursively creating builders for its fields.
- Specialized builders for `google.protobuf.Timestamp` and `google.type.Date` to handle their conversion to Arrow's `Timestamp` and `Date32` types respectively.
- Refactored the existing code to use the new builder pattern, removing the old procedural conversion logic.
- Added and updated tests to verify the new functionality.