### PR TITLE
feat: Add support for map type

### DIFF
--- a/protos/ptars_protos/bench.proto
+++ b/protos/ptars_protos/bench.proto
@@ -128,7 +128,7 @@ message ExampleMessage {
 //  map<string, sfixed32> sfixed32_string_map = 127;
 //  map<string, sfixed64> sfixed64_string_map = 128;
 //  map<string, bool> bool_string_map = 129;
-//  map<string, string> string_string_map = 130;
+  map<string, string> string_string_map = 130;
 //  map<string, bytes> bytes_string_map = 131;
 //  map<string, google.protobuf.DoubleValue> wrapped_double_string_map = 132;
 //  map<string, google.protobuf.FloatValue> wrapped_float_string_map = 133;

--- a/src/proto_to_arrow.rs
+++ b/src/proto_to_arrow.rs
@@ -2,6 +2,7 @@ use arrow::array::ArrayData;
 use arrow::buffer::Buffer;
 use arrow_array::builder::{ArrayBuilder, BinaryBuilder, StringBuilder};
 use arrow_array::types::{Date32Type, TimestampNanosecondType};
+use arrow::array::MapArray;
 use arrow_array::{Array, ListArray, RecordBatch, StructArray};
 use arrow_schema::{DataType, Field};
 use chrono::Datelike;
@@ -96,28 +97,25 @@ pub fn get_repeated_array_builder(
 pub fn get_array_builder(
     field_descriptor: &FieldDescriptor,
 ) -> Result<Box<dyn ProtoArrayBuilder>, &'static str> {
-    if field_descriptor.is_list() {
+    if field_descriptor.is_map() {
+        if let Kind::Message(message_descriptor) = field_descriptor.kind() {
+            Ok(Box::new(MapArrayBuilder::new(&message_descriptor)))
+        } else {
+            Err("map field is not a message")
+        }
+    } else if field_descriptor.is_list() {
         get_repeated_array_builder(field_descriptor)
-    } else if field_descriptor.is_map() {
-        Err("map not supported")
     } else {
         get_singular_array_builder(field_descriptor)
     }
 }
 
-pub fn singular_field_to_array(
+
+pub fn field_to_array(
     field_descriptor: &FieldDescriptor,
     messages: &[DynamicMessage],
 ) -> Result<Arc<dyn Array>, &'static str> {
-    let builder = get_singular_array_builder(field_descriptor)?;
-    Ok(read_primitive(messages, field_descriptor, builder))
-}
-
-pub fn read_primitive(
-    messages: &[DynamicMessage],
-    field_descriptor: &FieldDescriptor,
-    mut builder: Box<dyn ProtoArrayBuilder>,
-) -> Arc<dyn Array> {
+    let mut builder = get_array_builder(field_descriptor)?;
     for message in messages {
         if field_descriptor.supports_presence() && !message.has_field(field_descriptor) {
             builder.append_null();
@@ -125,31 +123,7 @@ pub fn read_primitive(
             builder.append(&message.get_field(field_descriptor));
         }
     }
-    builder.finish()
-}
-
-pub fn repeated_field_to_array(
-    field_descriptor: &FieldDescriptor,
-    messages: &[DynamicMessage],
-) -> Result<Arc<dyn Array>, &'static str> {
-    let mut builder = get_repeated_array_builder(field_descriptor)?;
-    for message in messages {
-        builder.append(&message.get_field(field_descriptor));
-    }
     Ok(builder.finish())
-}
-
-pub fn field_to_array(
-    field_descriptor: &FieldDescriptor,
-    messages: &[DynamicMessage],
-) -> Result<Arc<dyn Array>, &'static str> {
-    if field_descriptor.is_list() {
-        repeated_field_to_array(field_descriptor, messages)
-    } else if field_descriptor.is_map() {
-        Err("map not supported")
-    } else {
-        singular_field_to_array(field_descriptor, messages)
-    }
 }
 
 pub fn is_nullable(field: &FieldDescriptor) -> bool {
@@ -201,6 +175,91 @@ use arrow_array::builder::BooleanBuilder;
 
 use arrow_array::builder::PrimitiveBuilder;
 use arrow_array::ArrowPrimitiveType;
+
+struct MapArrayBuilder {
+    key_builder: Box<dyn ProtoArrayBuilder>,
+    value_builder: Box<dyn ProtoArrayBuilder>,
+    key_field_descriptor: FieldDescriptor,
+    value_field_descriptor: FieldDescriptor,
+    offsets: Vec<i32>,
+}
+
+impl MapArrayBuilder {
+    fn new(message_descriptor: &MessageDescriptor) -> Self {
+        let key_field_descriptor = message_descriptor.get_field_by_name("key").unwrap();
+        let value_field_descriptor = message_descriptor.get_field_by_name("value").unwrap();
+        let key_builder = get_singular_array_builder(&key_field_descriptor).unwrap();
+        let value_builder = get_singular_array_builder(&value_field_descriptor).unwrap();
+        Self {
+            key_builder,
+            value_builder,
+            key_field_descriptor,
+            value_field_descriptor,
+            offsets: vec![0],
+        }
+    }
+}
+
+impl ProtoArrayBuilder for MapArrayBuilder {
+    fn append(&mut self, value: &Value) {
+        if let Some(values) = value.as_list() {
+            for each_value in values {
+                let message = each_value.as_message().unwrap();
+                self.key_builder
+                    .append(&message.get_field(&self.key_field_descriptor));
+                self.value_builder
+                    .append(&message.get_field(&self.value_field_descriptor));
+            }
+        }
+        let last_offset = *self.offsets.last().unwrap();
+        self.offsets
+            .push(last_offset + value.as_list().map_or(0, |v| v.len() as i32));
+    }
+
+    fn append_null(&mut self) {
+        let last_offset = *self.offsets.last().unwrap();
+        self.offsets.push(last_offset);
+    }
+
+    fn finish(&mut self) -> Arc<dyn Array> {
+        let key_array = self.key_builder.finish();
+        let value_array = self.value_builder.finish();
+
+        let key_field = Arc::new(Field::new(
+            "key",
+            key_array.data_type().clone(),
+            is_nullable(&self.key_field_descriptor),
+        ));
+        let value_field = Arc::new(Field::new(
+            "value",
+            value_array.data_type().clone(),
+            is_nullable(&self.value_field_descriptor),
+        ));
+
+        let entry_struct = StructArray::from(vec![(key_field, key_array), (value_field, value_array)]);
+
+        let map_data_type = DataType::Map(
+            Arc::new(Field::new(
+                "entries",
+                entry_struct.data_type().clone(),
+                false,
+            )),
+            false,
+        );
+
+        let len = self.offsets.len() - 1;
+        let offsets_buffer = Buffer::from_vec(std::mem::take(&mut self.offsets));
+
+        let map_data = ArrayData::builder(map_data_type)
+            .len(len)
+            .add_buffer(offsets_buffer)
+            .add_child_data(entry_struct.into_data())
+            .build()
+            .unwrap();
+
+        Arc::new(MapArray::from(map_data))
+    }
+}
 
 struct MessageArrayBuilder {
     builders: BTreeMap<u32, Box<dyn ProtoArrayBuilder>>,


### PR DESCRIPTION
This commit adds support for the `map` type in the protobuf-to-arrow conversion.

A `MapArrayBuilder` is introduced to handle the conversion of protobuf `map` fields into Arrow `MapArray`.

The `get_array_builder` function is updated to use this new builder for map fields, and the `field_to_array` logic is streamlined.

The `string_string_map` field in `bench.proto` is uncommented to enable testing of this new functionality.