### PR TITLE
feat: add code coverage with codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,13 +40,23 @@ jobs:
         version: "0.7.19"
 
 
+    - name: Install grcov
+      run: cargo install grcov
+
     - name: Build
       run: |
         make develop
         make protoc
 
-    - name: Test
-      run: make test
+    - name: Run coverage
+      run: make coverage
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./lcov.info,./coverage.xml
+        fail_ci_if_error: true
 
   all-tests-pass:
     if: always()

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,11 @@ protoc: env
 .PHONY: lint
 lint:
 	cargo clippy -- -D warnings
+
+.PHONY: coverage
+coverage: develop
+	. .venv/bin/activate && \
+		coverage run --source=python/ptars -m pytest python/test/unit && \
+		coverage xml -o coverage.xml
+	CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="ptars-%p-%m.profraw" cargo test
+	grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing --ignore "target/*" --ignore "python/*" -o lcov.info


### PR DESCRIPTION
This commit adds code coverage reporting with Codecov.

It introduces a new `coverage` target in the `Makefile` to generate coverage reports for both Python and Rust code.

The CI workflow is updated to:
- Install `grcov`
- Run the `coverage` target
- Upload the generated reports (`lcov.info` and `coverage.xml`) to Codecov.